### PR TITLE
export url

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 | name         | default | options                                           |
 | ------------ | ------- | ------------------------------------------------- |
 | output-dir   | doc     | Your YARD product dir                             |
-| ruby-version | 3.2     | See options in https://github.com/ruby/setup-ruby |
+| ruby-version | 3.2     | See options in <https://github.com/ruby/setup-ruby> |
 
 ### Ruby version
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   deploy_yard:
+    # the deploy environment (not to be confused with env)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -43,6 +44,7 @@ jobs:
     name: Build and deploy YARD
     steps:
       - uses: kachick/deploy-yard-to-pages@v1.2.0
+        id: deployment
         # with:
           # # default `doc` as default of `.yardopts`
           # output-dir: 'docs'

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
     - uses: actions/configure-pages@v2
     - uses: actions/upload-pages-artifact@v1
       with:
-        # Upload entire repository
+        # By default, upload the docs directory
         path: ${{ inputs.output-dir }}
     - id: deployment
       uses: actions/deploy-pages@v1

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     description: 'YARD runner will be executed with this ruby version'
     required: true
     default: '3.2'
+outputs:
+  page_url:
+    description: "github page url"
+    value: ${{ steps.deployment.outputs.page_url }}
+
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
the example usage references a non-existant export

this PR
- exports the page URL
- and uses it in the readme example usage

(as well as some minor cleanups)